### PR TITLE
fix: initialize _bGraphicalCountdown and remove unsafe cr.$dispose()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+Makefile.in
+aclocal.m4
+configure
+autom4te.cache/
+install-sh
+missing

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@ configure
 autom4te.cache/
 install-sh
 missing
+src/schemas/gschemas.compiled
+po/*.gmo
+Makefile
+config.log
+config.status
+po/POTFILES
+po/stamp-it
+src/schemas/org.gnome.shell.extensions.teatime.gschema.xml
+src/schemas/org.gnome.shell.extensions.teatime.gschema.xml.in

--- a/po/Makefile.in.in
+++ b/po/Makefile.in.in
@@ -33,8 +33,7 @@ exec_prefix = @exec_prefix@
 datadir = @datadir@
 datarootdir = @datarootdir@
 libdir = @libdir@
-DATADIRNAME = @DATADIRNAME@
-itlocaledir = $(prefix)/$(DATADIRNAME)/locale
+localedir = @localedir@
 subdir = po
 install_sh = @install_sh@
 # Automake >= 1.8 provides @mkdir_p@.
@@ -80,7 +79,7 @@ INTLTOOL__v_MSGFMT_0 = @echo "  MSGFMT" $@;
 
 .po.pox:
 	$(MAKE) $(GETTEXT_PACKAGE).pot
-	$(MSGMERGE) $< $(GETTEXT_PACKAGE).pot -o $*.pox
+	$(MSGMERGE) $* $(GETTEXT_PACKAGE).pot -o $*.pox
 
 .po.mo:
 	$(INTLTOOL_V_MSGFMT)$(MSGFMT) -o $@ $<
@@ -108,7 +107,7 @@ install-data-no: all
 install-data-yes: all
 	linguas="$(USE_LINGUAS)"; \
 	for lang in $$linguas; do \
-	  dir=$(DESTDIR)$(itlocaledir)/$$lang/LC_MESSAGES; \
+	  dir=$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES; \
 	  $(mkdir_p) $$dir; \
 	  if test -r $$lang.gmo; then \
 	    $(INSTALL_DATA) $$lang.gmo $$dir/$(GETTEXT_PACKAGE).mo; \
@@ -142,15 +141,15 @@ install-exec installcheck:
 uninstall:
 	linguas="$(USE_LINGUAS)"; \
 	for lang in $$linguas; do \
-	  rm -f $(DESTDIR)$(itlocaledir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; \
-	  rm -f $(DESTDIR)$(itlocaledir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo.m; \
+	  rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; \
+	  rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(GETTEXT_PACKAGE).mo.m; \
 	done
 
 check: all $(GETTEXT_PACKAGE).pot
 	rm -f missing notexist
 	srcdir=$(srcdir) $(INTLTOOL_UPDATE) -m
 	if [ -r missing -o -r notexist ]; then \
-		exit 1; \
+	  exit 1; \
 	fi
 
 mostlyclean:

--- a/src/extension.js
+++ b/src/extension.js
@@ -70,6 +70,7 @@ let TeaTime = GObject.registerClass(
 			this.connect('style-changed', this._onStyleChanged.bind(this));
 
 			this._idleTimeout = null;
+			this._bGraphicalCountdown = true;
 
 			this._createMenu();
 			this._continueRunningTimer();

--- a/src/icon.js
+++ b/src/icon.js
@@ -87,7 +87,6 @@ export var TwoColorIcon = GObject.registerClass(
 			} catch (e) {
 				// ignore
 			}
-			cr.$dispose();
 		}
 	});
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,6 +1,6 @@
 {
   "shell-version": [
-    "47","48","49"
+    "47","48","49","50"
   ],
   "uuid": "TeaTime@oleid.mescharet.de",
   "name": "TeaTime",


### PR DESCRIPTION
P0 fixes:

- Initialize _bGraphicalCountdown before first use (prevents undefined !== true comparison when toggling setting before starting a timer)
- Remove cr.$dispose() call (internal GJS method, fragile across GNOME Shell versions)