### PR TITLE
fix: disconnect signal handlers, wire CSS class, remove dead schema key, fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+Makefile.in
+aclocal.m4
+configure
+autom4te.cache/
+install-sh
+missing
+src/schemas/gschemas.compiled
+po/*.gmo
+Makefile
+config.log
+config.status
+po/POTFILES
+po/stamp-it
+src/schemas/org.gnome.shell.extensions.teatime.gschema.xml
+src/schemas/org.gnome.shell.extensions.teatime.gschema.xml.in
+AGENTS.md

--- a/src/extension.js
+++ b/src/extension.js
@@ -89,9 +89,9 @@ let TeaTime = GObject.registerClass(
 
 		_createMenu() {
 			this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-			this._settings.connect("changed::" + this.config_keys.steep_times,
+			this._steepTimesSignalId = this._settings.connect("changed::" + this.config_keys.steep_times,
 				this._updateTeaList.bind(this));
-			this._settings.connect("changed::" + this.config_keys.graphical_countdown,
+			this._graphicalCountdownSignalId = this._settings.connect("changed::" + this.config_keys.graphical_countdown,
 				this._updateCountdownType.bind(this));
 
 			this.teaItemCont = new PopupMenu.PopupMenuSection();
@@ -108,7 +108,8 @@ let TeaTime = GObject.registerClass(
 			let bottom = new PopupMenu.PopupMenuSection();
 			this._customEntry = new St.Entry({
 				track_hover: true,
-				hint_text: _("min:sec")
+				hint_text: _("min:sec"),
+				style_class: 'teatime-custom-entry'
 			});
 			this._customEntry.get_clutter_text().set_max_length(10);
 			this._customEntry.get_clutter_text().connect("key-press-event", this._createCustomTimer.bind(this));
@@ -346,8 +347,14 @@ export default class TeaTimeExtension extends Extension {
 	}
 
 	disable() {
-		this._TeaTime._stopCountdown();
-		this._TeaTime.destroy();
-		delete this._TeaTime;
+		if (this._TeaTime) {
+			if (this._TeaTime._steepTimesSignalId)
+				this._TeaTime._settings.disconnect(this._TeaTime._steepTimesSignalId);
+			if (this._TeaTime._graphicalCountdownSignalId)
+				this._TeaTime._settings.disconnect(this._TeaTime._graphicalCountdownSignalId);
+			this._TeaTime._stopCountdown();
+			this._TeaTime.destroy();
+			delete this._TeaTime;
+		}
 	}
 }

--- a/src/icon.js
+++ b/src/icon.js
@@ -36,7 +36,7 @@ export var TwoColorIcon = GObject.registerClass(
 			// some fallback color
 			let [res, color] = Cogl.Color.from_string("rgb(150, 150, 150)");
 			this._primaryColor = color;
-			this._secundaryColor = color;
+			this._secondaryColor = color;
 			this._customStatus = null;
 		}
 
@@ -45,9 +45,9 @@ export var TwoColorIcon = GObject.registerClass(
 			this.margin_right = padding;
 		}
 
-		setColor(primary, secundary) {
+		setColor(primary, secondary) {
 			this._primaryColor = primary;
-			this._secundaryColor = secundary;
+			this._secondaryColor = secondary;
 			this.queue_repaint();
 		}
 
@@ -81,7 +81,7 @@ export var TwoColorIcon = GObject.registerClass(
 			try {
 				cr.scale(scaling, scaling);
 
-				this._drawingObject.draw(cr, this._customStatus, this._primaryColor, this._secundaryColor);
+				this._drawingObject.draw(cr, this._customStatus, this._primaryColor, this._secondaryColor);
 
 				cr.restore();
 			} catch (e) {
@@ -94,7 +94,7 @@ export var TwoColorIcon = GObject.registerClass(
 export var TeaPot = {
 	width: 484,
 	height: 295,
-	draw(cr, stat, primary, secundary) {
+	draw(cr, stat, primary, secondary) {
 		// draw TeaPot
 		// cairo commands generated from svg2cairo
 		// https://github.com/akrinke/svg2cairo
@@ -138,7 +138,7 @@ export var TeaPot = {
 export var Pie = {
 	width: 1,
 	height: 1,
-	draw(cr, stat, primary, secundary) {
+	draw(cr, stat, primary, secondary) {
 		const pi = Math.PI;
 		const r = 0.5;
 
@@ -147,7 +147,7 @@ export var Pie = {
 		cr.translate(0.5, 0.5);
 		cr.save();
 
-		Utils.setCairoColorFromClutter(cr, secundary);
+		Utils.setCairoColorFromClutter(cr, secondary);
 		cr.moveTo(0, 0);
 		cr.arc(0, 0, r, 3 / 2 * pi + 2 * pi * stat, 3 / 2 * pi + 2 *
 			pi);

--- a/src/schemas/org.gnome.shell.extensions.teatime.gschema.xml.in.in
+++ b/src/schemas/org.gnome.shell.extensions.teatime.gschema.xml.in.in
@@ -6,11 +6,6 @@
       <_summary>Tea drawing times list</_summary>
       <_description>A mapping of a teas to their corresponding drawing time in seconds.</_description>
     </key>
-    <key name="fullscreen-notification" type="b">
-      <default>false</default>
-      <summary>Show fullscreen notifications.</summary>
-      <description>Displays a more disrupting, modal fullscreen notification when the timer has elapsed.</description>
-    </key>
     <key name="graphical-countdown" type="b">
       <default>true</default>
       <summary>Show an animated graphical countdown.</summary>


### PR DESCRIPTION
P1 fixes:

- Disconnect GSettings signal handlers on disable to prevent memory leak on re-enable
- Apply .teatime-custom-entry CSS class to St.Entry (stylesheet.css was dead code)
- Remove unused fullscreen-notification key from GSettings schema
- Rename _secundaryColor → _secondaryColor (typo)