### PR TITLE
fix: correct schema name in README gnome-extensions pack command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A handy zip file can be created using:
   ```
 * or via gnome-extensions tools
   ```shell
-  ./autogen.sh && ./configure --prefix=/usr && make && gnome-extensions pack --podir=../po --schema=schemas/org.gnome.shell.extensions.teatimer.gschema.xml --extra-source=icon.js --extra-source=utils.js --extra-source=../utilities-teatime.svg --force src
+  ./autogen.sh && ./configure --prefix=/usr && make && gnome-extensions pack --podir=../po --schema=schemas/org.gnome.shell.extensions.teatime.gschema.xml --extra-source=icon.js --extra-source=utils.js --extra-source=../utilities-teatime.svg --force src
   ```
 
 Thanks to  Thomas Liebetraut for the new build system.


### PR DESCRIPTION
The example command referenced a non-existent  schema file — changed to .