### PR TITLE
fix: correct schema wording, extract alert color, add GStreamer cleanup, guard parseTime, add AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ po/POTFILES
 po/stamp-it
 src/schemas/org.gnome.shell.extensions.teatime.gschema.xml
 src/schemas/org.gnome.shell.extensions.teatime.gschema.xml.in
-AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Build & Install
+
+```bash
+./autogen.sh
+./configure --prefix=/usr && make
+make local-install  # installs to ~/.local/share/gnome-shell/extensions
+make zip            # creates distributable zip for extensions.gnome.org
+```
+
+Restart GNOME Shell (Alt+F2, r) after install if extension doesn't appear.
+
+## Code Formatting
+
+```bash
+./beautify-code.sh  # requires: pip install jsbeautifier
+```
+
+Run before commits. Uses tabs, jslint-happy style.
+
+## Architecture
+
+- **extension.js**: Main extension class, panel button, timer logic
+- **prefs.js**: GTK4/Adw preferences dialog
+- **utils.js**: Shared helpers (time parsing, sound playback via GStreamer)
+- **icon.js**: SVG icon rendering with Cairo
+- **schemas/**: GSettings schema (org.gnome.shell.extensions.teatime)
+
+Targets GNOME Shell 47-50. Uses ESM imports from `gi://` and `resource:///org/gnome/shell/`.
+
+## i18n
+
+Translation files in `po/`. Gettext domain: `TeaTime`. Run `po/update_strings.sh` to update .pot file.
+
+## Testing
+
+No automated tests. Test manually by installing locally and verifying in GNOME Shell. Check `journalctl -f` for extension errors.

--- a/src/extension.js
+++ b/src/extension.js
@@ -22,6 +22,8 @@ import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as Utils from './utils.js';
 import * as Icon from './icon.js';
 
+const ALERT_COLOR = "#f00";
+
 let PopupTeaMenuItem = GObject.registerClass(
 	class PopupTeaMenuItem extends PopupMenu.PopupBaseMenuItem {
 		_init(sTeaname, nBrewtime, params) {
@@ -77,7 +79,7 @@ let TeaTime = GObject.registerClass(
 			this._colorChanged = false;
 			this._menu_activate_id = this.menu.connect('activate', this._resetMenuItemColor.bind(this));
 
-			let [res, color] = Cogl.Color.from_string("#f00");
+			let [res, color] = Cogl.Color.from_string(ALERT_COLOR);
 			this._colorRed = color;
 		}
 
@@ -188,6 +190,7 @@ let TeaTime = GObject.registerClass(
 				event.get_key_symbol() == Clutter.KEY_KP_Enter) {
 
 				let seconds = Utils.parseTime(text.get_text())
+				if (isNaN(seconds) || seconds <= 0) return;
 				if (seconds > 0) {
 					this._initCountdown(new Date(), seconds);
 					this.menu.close();
@@ -341,10 +344,13 @@ let TeaTime = GObject.registerClass(
 			this._graphicalTimer.setScaling(scaling);
 		}
 		destroy() {
-			this._removeIdleTimeout(); // only for shexli
-			this._settings.disconnect(this._setting_changed_id);
-			this._settings.disconnect(this._settings_change2_id);
-			this._menu.disconnect(this._menu_activate_id);
+			this._removeIdleTimeout();
+			if (this._steepTimesSignalId)
+				this._settings.disconnect(this._steepTimesSignalId);
+			if (this._graphicalCountdownSignalId)
+				this._settings.disconnect(this._graphicalCountdownSignalId);
+			if (this._menu_activate_id)
+				this.menu.disconnect(this._menu_activate_id);
 			super.destroy();
 		}
 	});
@@ -356,6 +362,7 @@ export default class TeaTimeExtension extends Extension {
 	}
 
 	disable() {
+		Utils.stopSound();
 		if (this._TeaTime) {
 			if (this._TeaTime._steepTimesSignalId)
 				this._TeaTime._settings.disconnect(this._TeaTime._steepTimesSignalId);

--- a/src/extension.js
+++ b/src/extension.js
@@ -191,10 +191,8 @@ let TeaTime = GObject.registerClass(
 
 				let seconds = Utils.parseTime(text.get_text())
 				if (isNaN(seconds) || seconds <= 0) return;
-				if (seconds > 0) {
-					this._initCountdown(new Date(), seconds);
-					this.menu.close();
-				}
+				this._initCountdown(new Date(), seconds);
+				this.menu.close();
 				this._customEntry.set_text("");
 			}
 		}

--- a/src/schemas/org.gnome.shell.extensions.teatime.gschema.xml.in.in
+++ b/src/schemas/org.gnome.shell.extensions.teatime.gschema.xml.in.in
@@ -3,8 +3,8 @@
   <schema id="@GSETTINGS_SCHEMA@" path="/org/gnome/shell/extensions/teatime/" gettext-domain="@GETTEXT_DOMAIN@">
     <key name="steep-times" type="a{su}">
       <_default l10n="messages">{ "Green tea": 180, "Black tea": 210, "Fruit tea": 420, "White tea": 120 }</_default>
-      <_summary>Tea drawing times list</_summary>
-      <_description>A mapping of a teas to their corresponding drawing time in seconds.</_description>
+      <_summary>Tea steeping times list</_summary>
+      <_description>A mapping of a teas to their corresponding steeping time in seconds.</_description>
     </key>
     <key name="graphical-countdown" type="b">
       <default>true</default>
@@ -14,12 +14,12 @@
     <key name="alarm-sound-file" type="s">
       <default>"file:///usr/share/sounds/freedesktop/stereo/complete.oga"</default>
       <summary>Drawing completed sound</summary>
-      <description>A sound file played after drawing is completed.</description>
+      <description>A sound file played after steeping is completed.</description>
     </key>
     <key name="use-alarm-sound" type="b">
       <default>true</default>
-      <summary>Play sound when drawing completed</summary>
-      <description>Play a sound file after drawing is completed.</description>
+      <summary>Play sound when steeping completed</summary>
+      <description>Play a sound file after steeping is completed.</description>
     </key>
     <key name="running-timer" type="s">
       <default>"-"</default>

--- a/src/schemas/org.gnome.shell.extensions.teatime.gschema.xml.in.in
+++ b/src/schemas/org.gnome.shell.extensions.teatime.gschema.xml.in.in
@@ -13,7 +13,7 @@
     </key>
     <key name="alarm-sound-file" type="s">
       <default>"file:///usr/share/sounds/freedesktop/stereo/complete.oga"</default>
-      <summary>Drawing completed sound</summary>
+      <summary>Steeping completed sound</summary>
       <description>A sound file played after steeping is completed.</description>
     </key>
     <key name="use-alarm-sound" type="b">

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,6 +74,12 @@ export function playSound(uri) {
 	_player.set_state(Gst.State.PLAYING);
 }
 
+export function stopSound() {
+	if (_player) {
+		_player.set_state(Gst.State.NULL);
+	}
+}
+
 export function setCairoColorFromClutter(cr, c) {
 	let s = 1.0 / 255;
 	cr.setSourceRGBA(s * c.red, s * c.green, s * c.blue, s * c.alpha);


### PR DESCRIPTION
### Changes
- Correct schema descriptions from 'drawing' to 'steeping'
- Extract inline `#f00` to `ALERT_COLOR` constant
- Add `stopSound()` in utils.js, call from disable() to clean up GStreamer player
- Guard `parseTime()` result against NaN/negative before starting countdown
- Fix `destroy()` signal handler IDs from bad merge (`_setting_changed_id` → `_steepTimesSignalId`, `this._menu` → `this.menu`)
- Remove dead branch after parseTime guard
- Add AGENTS.md (tracked, removed from .gitignore)

### Review
Clean aside from the two issues found and fixed in 1ebf756.